### PR TITLE
Derive sexp_of for many constructs

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
  (libraries core_kernel ocamlgraph)
  (inline_tests)
  (preprocess
-  (pps ppx_deriving.show ppx_inline_test)))
+  (pps ppx_deriving.show ppx_inline_test ppx_sexp_conv)))
 
 (ocamllex
  (modules lexer))

--- a/lib/err.ml
+++ b/lib/err.ml
@@ -8,8 +8,10 @@ type user_error =
   | RedefinedRecursionName of string * source_loc * source_loc
   | Uncategorised of string
   | InvalidCommandLineParam of string
+[@@deriving sexp_of]
 
 exception UserError of user_error
+[@@deriving sexp_of]
 (** UserError is a user error and should be reported back so it can be fixed *)
 
 let show_user_error = function
@@ -28,11 +30,12 @@ let show_user_error = function
   | InvalidCommandLineParam msg -> "Invalid command line parameter: " ^ msg
 
 exception Violation of string
+[@@deriving sexp_of]
 (** A Violation is reported when an impossible state was reached. It has to
     be considered a bug even when the fix is to change the Violation to a
     user error *)
 
-exception UnImplemented of string
+exception UnImplemented of string [@@deriving sexp_of]
 
 let unimpl desc = UnImplemented desc |> raise
 

--- a/lib/ltype.ml
+++ b/lib/ltype.ml
@@ -10,6 +10,7 @@ type t =
   | TVarL of name
   | MuL of name * t
   | EndL
+[@@deriving sexp_of]
 
 let show =
   let indent_here indent = String.make (indent * 2) ' ' in
@@ -40,7 +41,7 @@ let show =
   in
   show_local_type_internal 0
 
-exception Unmergable of t * t
+exception Unmergable of t * t [@@deriving sexp_of]
 
 let rec merge projected_role lty1 lty2 =
   let fail () = raise (Unmergable (lty1, lty2)) in

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -2,6 +2,8 @@ open! Core_kernel
 
 type source_loc = Lexing.position * Lexing.position
 
+let sexp_of_source_loc _ = Sexp.Atom "<opaque>"
+
 let render_pos pos =
   sprintf "%d:%d" pos.Lexing.pos_lnum
     (pos.Lexing.pos_cnum - pos.Lexing.pos_bol + 1)
@@ -24,7 +26,7 @@ type 'a located =
  *   | Con of string *)
 
 (* a simple name *)
-type name = string [@@deriving show {with_path= false}]
+type name = string [@@deriving show {with_path= false}, sexp_of]
 
 (* a qualified name *)
 type raw_qname = name list
@@ -82,6 +84,8 @@ let show_message = function
   | MessageQName qn -> qname_to_string qn
 
 let pp_message fmt m = Format.fprintf fmt "%s" (show_message m)
+
+let sexp_of_message m = Sexp.Atom (show_message m)
 
 let message_label = function
   | Message {name; _} -> name


### PR DESCRIPTION
Exn.to_string printed a disappointing underscore without much
explanation when an exception is raised and printed.
This is because the string conversion uses sexp and our exceptions are
not sexp ready.
This commits adds derived sexp to many constructs so exception printing
are better.

Ref: https://ocaml.janestreet.com/ocaml-core/latest/doc/base/Base/Exn/index.html

Example of it working:
fz315@stives % dune exec nuscr TwoPC2.scr
Reported problem:  
 (lib/ltype.ml.Unmergable (TVarL t)
  (ChoiceL P2
    ((SendL "supply()" C2
       (MuL t2
         (ChoiceL P2
           ((SendL "supply()" C2 (TVarL t2)) (SendL "eos()" C2 EndL)))))
      (SendL "eos()" C2 EndL))))
