### PR TITLE
Event Style Code Generation

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -40,6 +40,9 @@ let argspec =
     , Arg.String (fun s -> fsm := parse_role_protocol_exn s |> Some)
     , ": project the CFSM for the specified role" )
   ; ( "-project"
+    , Arg.String (fun s -> project := parse_role_protocol_exn s |> Some)
+    , ": project the local types for the specified role" )
+  ; ( "-gencode"
     , Arg.String (fun s -> gencode := parse_role_protocol_exn s |> Some)
     , ": generate OCaml code for the specified role" ) ]
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -41,7 +41,7 @@ let argspec =
     , ": project the CFSM for the specified role" )
   ; ( "-project"
     , Arg.String (fun s -> project := parse_role_protocol_exn s |> Some)
-    , ": project the local types for the specified role" )
+    , ": project the local type for the specified role" )
   ; ( "-gencode"
     , Arg.String (fun s -> gencode := parse_role_protocol_exn s |> Some)
     , ": generate OCaml code for the specified role" ) ]

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -115,6 +115,15 @@ let find_all_payloads g =
   in
   G.fold_edges_e f g (S.singleton "string") |> S.to_list
 
+let find_all_roles g =
+  let module S = String.Set in
+  let f (_, a, _) acc =
+    match a with
+    | SendA (r, _) | RecvA (r, _) -> S.add acc r
+    | _ -> failwith "Impossible"
+  in
+  G.fold_edges_e f g S.empty |> S.to_list
+
 let gen_comms_typedef payload_types =
   let mk_recv payload_ty_str =
     let payload_ty = mk_constr payload_ty_str in
@@ -137,13 +146,25 @@ let gen_comms_typedef payload_types =
   in
   Str.type_ Asttypes.Nonrecursive [comms]
 
+let gen_role_ty roles =
+  let f role = Rtag (Location.mknoloc role, [], true, []) in
+  let role_ty = Typ.variant (List.map ~f roles) Asttypes.Closed None in
+  role_ty
+
 let gen_ast (_proto, _role) (_start, g) : structure =
   let loc = Location.none in
   let callback_typedef = gen_callback_typedef g in
   let payload_types = find_all_payloads g in
   let comms_typedef = gen_comms_typedef payload_types in
-  let vb = [%stri let hello = "hello"] in
-  [callback_typedef; comms_typedef; vb]
+  let roles = find_all_roles g in
+  let role_ty = gen_role_ty roles in
+  let run_expr = [%expr ()] in
+  let run =
+    [%stri
+      let run (router : [%t role_ty] -> comms) (callbacks : callbacks) =
+        [%e run_expr]]
+  in
+  [callback_typedef; comms_typedef; run]
 
 let gen_code (proto, role) (start, g) =
   let buffer = Buffer.create 4196 in

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -6,7 +6,6 @@ open Asttypes
 open Longident
 open! Ast_helper
 module S = Set
-
 open Syntax
 open Efsm
 

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -5,6 +5,30 @@ open! Migrate_parsetree
 
 open! Ast_407
 open Parsetree
+open Efsm
+
+let state_action_type (g : G.t) (st : int) =
+  let merge_state_action_type aty1 aty2 =
+    match (aty1, aty2) with
+    | `Terminal, aty2 -> aty2
+    | aty1, `Terminal -> aty1
+    | `Send, `Send -> `Send
+    | `Recv, `Recv -> `Recv
+    | `Send, `Recv -> `Mixed
+    | `Recv, `Send -> `Mixed
+    | aty1, `Mixed -> aty1
+    | `Mixed, aty2 -> aty2
+  in
+  let f (_, a, _) acc =
+    let aty =
+      match a with
+      | SendA _ -> `Send
+      | RecvA _ -> `Recv
+      | Epsilon -> failwith "Impossible"
+    in
+    merge_state_action_type aty acc
+  in
+  G.fold_succ_e f g st `Terminal
 
 let gen_ast (_proto, _role) (_start, _g) : structure =
   let loc = Location.none in
@@ -17,7 +41,7 @@ let gen_code (proto, role) (start, g) =
   let buffer = Buffer.create 4196 in
   let formatter = Format.formatter_of_buffer buffer in
   let ast = gen_ast (proto, role) (start, g) in
-  let ast = migrate.copy_structure ast in
+  let ast = migrate.Versions.copy_structure ast in
   Pprintast.structure formatter ast ;
   Format.pp_print_flush formatter () ;
   Buffer.contents buffer

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1,21 +1,23 @@
 open! Core_kernel
+open! Migrate_parsetree
 
 (* open Efsm *)
 
-open Ocaml_common
+open! Ast_407
+open Parsetree
 
-let gen_ast (_proto, _role) (_start, _g) : Parsetree.structure =
-  let open Ast_helper in
-  let open Location in
-  let vb =
-    Vb.mk (Pat.var (mknoloc "hello")) (Exp.constant (Const.string "Hello"))
-  in
-  [Str.value Asttypes.Nonrecursive [vb]]
+let gen_ast (_proto, _role) (_start, _g) : structure =
+  let loc = Location.none in
+  let vb = [%stri let hello = "hello"] in
+  [vb]
+
+let migrate = Versions.migrate Versions.ocaml_407 Versions.ocaml_current
 
 let gen_code (proto, role) (start, g) =
   let buffer = Buffer.create 4196 in
   let formatter = Format.formatter_of_buffer buffer in
   let ast = gen_ast (proto, role) (start, g) in
+  let ast = migrate.copy_structure ast in
   Pprintast.structure formatter ast ;
   Format.pp_print_flush formatter () ;
   Buffer.contents buffer

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1,0 +1,21 @@
+open! Core_kernel
+
+(* open Efsm *)
+
+open Ocaml_common
+
+let gen_ast (_proto, _role) (_start, _g) : Parsetree.structure =
+  let open Ast_helper in
+  let open Location in
+  let vb =
+    Vb.mk (Pat.var (mknoloc "hello")) (Exp.constant (Const.string "Hello"))
+  in
+  [Str.value Asttypes.Nonrecursive [vb]]
+
+let gen_code (proto, role) (start, g) =
+  let buffer = Buffer.create 4196 in
+  let formatter = Format.formatter_of_buffer buffer in
+  let ast = gen_ast (proto, role) (start, g) in
+  Pprintast.structure formatter ast ;
+  Format.pp_print_flush formatter () ;
+  Buffer.contents buffer

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -97,6 +97,7 @@ let gen_callback_typedef (g : G.t) : structure_item =
         G.fold_succ_e gen_recv g st acc
   in
   let callbacks = G.fold_vertex f g [] in
+  let callbacks = List.rev callbacks in
   let callbacks =
     Type.mk ~kind:(Ptype_record callbacks) (Location.mknoloc "callbacks")
   in

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1,15 +1,12 @@
 open! Core_kernel
-open! Migrate_parsetree
 
 (* open Efsm *)
 
-open! Ast_407
+open! Ppxlib_ast
 open Parsetree
-open Ast_helper
+open! Ast_helper
 open Syntax
 open Efsm
-
-let migrate = Versions.migrate Versions.ocaml_407 Versions.ocaml_current
 
 let state_action_type (g : G.t) (st : int) =
   let merge_state_action_type aty1 aty2 =
@@ -115,7 +112,6 @@ let gen_code (proto, role) (start, g) =
   let buffer = Buffer.create 4196 in
   let formatter = Format.formatter_of_buffer buffer in
   let ast = gen_ast (proto, role) (start, g) in
-  let ast = migrate.Versions.copy_structure ast in
   Pprintast.structure formatter ast ;
   Format.pp_print_flush formatter () ;
   Buffer.contents buffer

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -5,7 +5,11 @@ open! Migrate_parsetree
 
 open! Ast_407
 open Parsetree
+open Ast_helper
+open Syntax
 open Efsm
+
+let migrate = Versions.migrate Versions.ocaml_407 Versions.ocaml_current
 
 let state_action_type (g : G.t) (st : int) =
   let merge_state_action_type aty1 aty2 =
@@ -30,12 +34,56 @@ let state_action_type (g : G.t) (st : int) =
   in
   G.fold_succ_e f g st `Terminal
 
-let gen_ast (_proto, _role) (_start, _g) : structure =
-  let loc = Location.none in
-  let vb = [%stri let hello = "hello"] in
-  [vb]
+type x = {a: int; b: int}
 
-let migrate = Versions.migrate Versions.ocaml_407 Versions.ocaml_current
+let gen_callback_typedef (g : G.t) : structure_item =
+  let loc = Location.none in
+  let f st acc =
+    match state_action_type g st with
+    | `Mixed -> failwith "Impossible"
+    | `Terminal -> acc
+    | `Send ->
+        let gen_recv (_, _a, _) acc = acc in
+        G.fold_succ_e gen_recv g st acc
+    | `Recv ->
+        let gen_recv (_, a, _) (typedefs, callbacks) =
+          match a with
+          | RecvA (_, msg) ->
+              let label = message_label msg in
+              let payload_type = message_payload_ty msg in
+              let mk_constr id =
+                Typ.constr (Location.mknoloc (Longident.parse id)) []
+              in
+              let payload_type =
+                match payload_type with
+                | [] -> [%type: unit]
+                | [x] -> mk_constr x
+                | _ -> Typ.tuple (List.map ~f:mk_constr payload_type)
+              in
+              let fieldTy =
+                Typ.arrow Asttypes.Nolabel payload_type [%type: unit]
+              in
+              let fieldName = sprintf "state%dReceive%s" st label in
+              let field = Type.field (Location.mknoloc fieldName) fieldTy in
+              (typedefs, field :: callbacks)
+          | _ -> failwith "Impossible"
+        in
+        G.fold_succ_e gen_recv g st acc
+  in
+  let _typedefs, callbacks = G.fold_vertex f g ([], []) in
+  let callbacks =
+    Type.mk ~kind:(Ptype_record callbacks) (Location.mknoloc "callbacks")
+  in
+  let ret = Str.type_ Asttypes.Nonrecursive [callbacks] in
+  (* let ret_ = migrate.Versions.copy_structure [ret] in Printast.structure 0
+     (Format.formatter_of_out_channel stdout) ret_ ; *)
+  ret
+
+let gen_ast (_proto, _role) (_start, g) : structure =
+  let loc = Location.none in
+  let callback_typedef = gen_callback_typedef g in
+  let vb = [%stri let hello = "hello"] in
+  [callback_typedef; vb]
 
 let gen_code (proto, role) (start, g) =
   let buffer = Buffer.create 4196 in

--- a/lib/codegen.mli
+++ b/lib/codegen.mli
@@ -1,0 +1,12 @@
+(** Code generation from EFSM *)
+
+(** This module transforms a EFSM generated from local types into OCaml code. *)
+
+open Syntax
+open! Ppxlib_ast
+
+val gen_ast : name * name -> int * Efsm.G.t -> Parsetree.structure
+(** Generate AST presentation of a projected EFSM *)
+
+val gen_code : name * name -> int * Efsm.G.t -> string
+(** Generate string representation of a projected EFSM *)

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (flags
   (:standard -w +A-39-4-42))
  (name nuscrlib)
- (libraries base stdio ocamlgraph)
+ (libraries base stdio ocamlgraph ppxlib)
  (inline_tests)
  (preprocess
   (pps ppx_deriving.show ppx_inline_test ppx_sexp_conv)))

--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
  (libraries base stdio ocamlgraph ppxlib)
  (inline_tests)
  (preprocess
-  (pps ppx_deriving.show ppx_inline_test ppx_sexp_conv)))
+  (pps ppx_deriving.show ppx_inline_test ppx_sexp_conv ppxlib.metaquot)))
 
 (ocamllex
  (modules lexer))

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -93,6 +93,17 @@ let message_label = function
   | MessageName name -> name
   | MessageQName qn -> qname_to_string qn
 
+let message_payload_ty =
+  let payload_type_of_payload_t = function
+    | PayloadName n -> n
+    | PayloadDel (_p, _r) -> failwith "Delegation is not supported"
+    | PayloadQName qn -> qname_to_string qn
+    | PayloadBnd (_n, qn) -> qname_to_string qn
+  in
+  function
+  | Message {payload; _} -> List.map ~f:payload_type_of_payload_t payload
+  | _ -> []
+
 type global_interaction = raw_global_interaction located
 [@@deriving show {with_path= false}]
 

--- a/nuscr.opam
+++ b/nuscr.opam
@@ -22,4 +22,5 @@ depends: [
   "js_of_ocaml"
   "js_of_ocaml-ppx"
   "js_of_ocaml-tyxml"
+  "ppxlib"
 ]


### PR DESCRIPTION
This pull request adds event style API generation.

In a nutshell

send states have a callback of type:
``'env -> ('env * [ `label1 of payload1 | `label2 of payload2 | ... ])``

receive states have callbacks of type:
`'env -> payload1 -> 'env`
`'env -> payload2 -> 'env`
...

Example Protocol:
```
global protocol TwoBuyer(role A, role B, role S)
{
	title(int) from A to S;
	quote(x: int) from S to A;
	quote(y: int) from S to B;
	quoteByTwo(z:int) from A to B;
	choice at B
	{
		ok(int) from B to S;
		empty1(int) from S to B;
	}
	or
	{
		quit() from B to S;
	}
}
```

role A:
```
type nonrec 'env callbacks =
  {
  state0Send: 'env -> ('env * [ `title of int ]) ;
  state1Receivequote: 'env -> int -> 'env ;
  state2Send: 'env -> ('env * [ `quoteByTwo of int ]) }
```
c.f. local type
```
title(int) to S;
quote(x: int) from S;
quoteByTwo(z: int) to B;
end
```

role B:
```
type nonrec 'env callbacks =
  {
  state0Receivequote: 'env -> int -> 'env ;
  state1ReceivequoteByTwo: 'env -> int -> 'env ;
  state2Send: 'env -> ('env * [ `quit of unit  | `ok of int ]) ;
  state4Receiveempty1: 'env -> int -> 'env }
```
c.f. local type
```
quote(y: int) from S;
quoteByTwo(z: int) from A;
choice at B {
  ok(int) to S;
  empty1(int) from S;
  end
} or {
  quit() to S;
  end
}
```

role S:
```
type nonrec 'env callbacks =
  {
  state0Receivetitle: 'env -> int -> 'env ;
  state1Send: 'env -> ('env * [ `quote of int ]) ;
  state2Send: 'env -> ('env * [ `quote of int ]) ;
  state3Receiveok: 'env -> int -> 'env ;
  state3Receivequit: 'env -> unit -> 'env ;
  state5Send: 'env -> ('env * [ `empty1 of int ]) }
```
c.f. local type
```
title(int) from A;
quote(x: int) to A;
quote(y: int) to B;
choice at B {
  ok(int) from B;
  empty1(int) to B;
  end
} or {
  quit() from B;
  end
}
```