### PR TITLE
Fix test

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,8 @@
 (library
  (name nuscrlib_tests)
- (inline_tests)
+ (inline_tests
+  (deps
+   (source_tree ../examples)))
  (libraries nuscr.lib base stdio)
  (preprocess
   (pps ppx_inline_test)))

--- a/test/test.ml
+++ b/test/test.ml
@@ -105,5 +105,8 @@ let () =
     in
     let ok, err, errors = process_files files in
     let report = write_report dirs ok err errors in
-    print_endline (if err = 0 then "Ok" else "Not ok\n" ^ report)
-  with e -> "Unexpected:\n" ^ Exn.to_string e |> print_endline
+    print_endline (if err = 0 then "Ok" else "Not ok\n" ^ report) ;
+    if err <> 0 then Caml.exit 1
+  with e ->
+    "Unexpected:\n" ^ Exn.to_string e |> print_endline ;
+    Caml.exit 1


### PR DESCRIPTION
Makes examples directory a dependency of test rule in dune. 
So `dune runtest` reruns when a test file is changed.
Test now correctly exits with status 1 when things fail. Closes #63 