### PR TITLE
Refactor: Don't use List.find to check pragmas

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -110,12 +110,8 @@ let generate_code (ast : Syntax.scr_module) gencode =
   match gencode with
   | Some (role, protocol) ->
       let impl =
-        match
-          List.find ast.pragmas ~f:(fun (pragma, _) ->
-              match pragma with NestedProtocols -> true | _ -> false)
-        with
-        | None -> gen_ocaml role protocol
-        | Some _ -> gen_go protocol
+        if Pragma.nested_protocol_enabled ast then gen_go protocol
+        else gen_ocaml role protocol
       in
       print_endline impl
   | None -> ()

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -83,9 +83,9 @@ let gen_output ast f = function
 let process_pragmas (pragmas : Syntax.pragmas) : unit =
   let process_global_pragma (k, v) =
     match (k, v) with
-    | `PrintUsage, _ -> usage () |> print_endline
-    | `ShowPragmas, _ -> Syntax.show_pragmas pragmas |> print_endline
-    | `NestedProtocols, _ ->
+    | Syntax.PrintUsage, _ -> usage () |> print_endline
+    | Syntax.ShowPragmas, _ -> Syntax.show_pragmas pragmas |> print_endline
+    | Syntax.NestedProtocols, _ ->
         if Option.is_some !fsm then
           Err.uerr (Err.IncompatibleFlag ("fsm", Syntax.show_pragma k))
   in
@@ -112,7 +112,7 @@ let generate_code (ast : Syntax.scr_module) gencode =
       let impl =
         match
           List.find ast.pragmas ~f:(fun (pragma, _) ->
-              match pragma with `NestedProtocols -> true | _ -> false)
+              match pragma with NestedProtocols -> true | _ -> false)
         with
         | None -> gen_ocaml role protocol
         | Some _ -> gen_go protocol

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -82,7 +82,7 @@ let validate_nested_protocols (ast : scr_module) ~verbose =
 let validate_exn (ast : scr_module) ~verbose : unit =
   match
     List.find ast.pragmas ~f:(fun (pragma, _) ->
-        match pragma with `NestedProtocols -> true | _ -> false)
+        match pragma with NestedProtocols -> true | _ -> false)
   with
   | None ->
       Protocol.ensure_no_nested_protocols ast ;
@@ -118,7 +118,7 @@ let enumerate_nested_protocols (ast : scr_module) :
 let enumerate (ast : scr_module) : (ProtocolName.t * RoleName.t) list =
   match
     List.find ast.pragmas ~f:(fun (pragma, _) ->
-        match pragma with `NestedProtocols -> true | _ -> false)
+        match pragma with NestedProtocols -> true | _ -> false)
   with
   | None -> enumerate_protocols ast
   | Some (_, _) -> enumerate_nested_protocols ast
@@ -145,7 +145,7 @@ let project_nested_protocol ast ~protocol ~role : Ltype.t =
 let project_role ast ~protocol ~role : Ltype.t =
   match
     List.find ast.pragmas ~f:(fun (pragma, _) ->
-        match pragma with `NestedProtocols -> true | _ -> false)
+        match pragma with NestedProtocols -> true | _ -> false)
   with
   | None -> project_protocol_role ast ~protocol ~role
   | Some (_, _) -> project_nested_protocol ast ~protocol ~role

--- a/lib/pragma.ml
+++ b/lib/pragma.ml
@@ -18,3 +18,8 @@ let parse_pragmas_from_lexbuf lexbuf : Syntax.pragmas =
 
 let parse_pragmas_string string =
   parse_pragmas_from_lexbuf @@ Lexing.from_string string
+
+let nested_protocol_enabled ast =
+  List.exists
+    ~f:(fun (p, _) -> Poly.( = ) p Syntax.NestedProtocols)
+    ast.Syntax.pragmas

--- a/lib/pragma.mli
+++ b/lib/pragma.mli
@@ -1,2 +1,5 @@
 val parse_pragmas_string : string -> Syntax.pragmas
 (** Parse a string into {!Syntax.pragmas}. *)
+
+val nested_protocol_enabled : Syntax.scr_module -> bool
+(** Whether nested protocol pragma is enabled for a given module *)

--- a/lib/protocol.ml
+++ b/lib/protocol.ml
@@ -172,7 +172,7 @@ let expand_global_protocol (scr_module : scr_module)
 let ensure_no_nested_protocols (ast : scr_module) =
   let pragma_err =
     PragmaNotSet
-      ( show_pragma `NestedProtocols
+      ( show_pragma NestedProtocols
       , "Nested protocols cannot be used without setting this pragma" )
   in
   let rec no_nested_protocols {loc= _; value= protocol} =

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -10,14 +10,13 @@ open Loc
 
 (* association list of pragmas *)
 
-type pragma = [`NestedProtocols | `ShowPragmas | `PrintUsage]
-[@@deriving show]
+type pragma = NestedProtocols | ShowPragmas | PrintUsage [@@deriving show]
 
 let pragma_of_string str : pragma =
   match str with
-  | "ShowPragmas" -> `ShowPragmas
-  | "PrintUsage" -> `PrintUsage
-  | "NestedProtocols" -> `NestedProtocols
+  | "ShowPragmas" -> ShowPragmas
+  | "PrintUsage" -> PrintUsage
+  | "NestedProtocols" -> NestedProtocols
   | prg -> Err.UnknownPragma prg |> Err.uerr
 
 type pragmas = (pragma * string option) list [@@deriving show]

--- a/test/test.ml
+++ b/test/test.ml
@@ -64,9 +64,9 @@ exception ExpectFail
 let process_pragmas (pragmas : Nuscrlib.Syntax.pragmas) : unit =
   let process_global_pragma ((k : Nuscrlib.Syntax.pragma), v) =
     match (k, v) with
-    | `PrintUsage, _ -> ()
-    | `ShowPragmas, _ -> ()
-    | `NestedProtocols, _ -> ()
+    | PrintUsage, _ -> ()
+    | ShowPragmas, _ -> ()
+    | NestedProtocols, _ -> ()
   in
   List.iter ~f:process_global_pragma pragmas
 


### PR DESCRIPTION
also use a union type for pragmas instead of polymorphic variants

/cc @becharrens 