### PR TITLE
Add OCaml 5.4 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
         ocaml-version:
           - 5.4
           - 5.3
-          - 4
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         ocaml-version:
+          - 5.4
           - 5.3
           - 4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,6 @@ jobs:
 
       - run: opam exec -- dune runtest
 
-      - run: opam install ocamlformat=0.27.0
+      - run: opam install ocamlformat=0.29.0
 
       - run: opam exec -- dune build @fmt

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -3,4 +3,4 @@ break-cases = fit
 margin = 77
 parse-docstrings = true
 wrap-comments = true
-version = 0.27.0
+version = 0.29.0

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -188,7 +188,7 @@ let main args global_actions local_actions =
       if args.enumerate then
         Nuscrlib.enumerate ast
         |> List.map ~f:(fun (n, r) ->
-               RoleName.user r ^ "@" ^ ProtocolName.user n )
+            RoleName.user r ^ "@" ^ ProtocolName.user n )
         |> String.concat ~sep:"\n" |> print_endline
     in
     `Ok ()

--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@
    "A toolkit to manipulate Scribble-style multiparty protocols, based on classical multiparty session type theory. The toolkit provides means to define global protocols, project to local protocols, convert local protocols to a CFSM representation, and generate OCaml code for protocol implementations.")
  (depends
   (ocaml
-   (>= 4.10))
+   (>= 5.1))
   (menhir
    (>= 20190924))
   (sedlex

--- a/dune-project
+++ b/dune-project
@@ -38,19 +38,19 @@
    (>= 5.2))
   dune
   (base
-   (>= v0.12.0))
+   (>= v0.17))
   (stdio
-   (>= v0.12.0))
+   (>= v0.17))
   (ppx_sexp_conv
-   (>= v0.12.0))
+   (>= v0.17))
   (ppx_here
-   (>= v0.12.0))
+   (>= v0.17))
   (z3 :with-test)
   (odoc :with-doc)
   (ocamlgraph
    (>= 1.8.8))
   (ppxlib
-   (>= 0.22.0))
+   (>= 0.36.0))
   (cmdliner
    (>= 1.1.0))
   (process

--- a/lib/mpst/expr.mli
+++ b/lib/mpst/expr.mli
@@ -9,13 +9,13 @@ open Syntax.Exprs
 (** An expression, used in RefinementType extension
 
     {v
- type t =
-   | Var of VariableName.t  (** A variable *)
-   | Int of int  (** An integer constant *)
-   | Bool of bool  (** An boolean constant *)
-   | String of string  (** A string literal *)
-   | Binop of binop * t * t  (** A binary operator *)
-   | Unop of unop * t  (** An unary operator *)
+    type t =
+      | Var of VariableName.t  (** A variable *)
+      | Int of int  (** An integer constant *)
+      | Bool of bool  (** An boolean constant *)
+      | String of string  (** A string literal *)
+      | Binop of binop * t * t  (** A binary operator *)
+      | Unop of unop * t  (** An unary operator *)
     v} *)
 type t = expr [@@deriving sexp_of, eq, ord, show]
 

--- a/nuscr.opam
+++ b/nuscr.opam
@@ -18,14 +18,14 @@ depends: [
   "sedlex" {>= "2.5"}
   "ppx_deriving" {>= "5.2"}
   "dune" {>= "2.8"}
-  "base" {>= "v0.12.0"}
-  "stdio" {>= "v0.12.0"}
-  "ppx_sexp_conv" {>= "v0.12.0"}
-  "ppx_here" {>= "v0.12.0"}
+  "base" {>= "v0.17"}
+  "stdio" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
   "z3" {with-test}
   "odoc" {with-doc}
   "ocamlgraph" {>= "1.8.8"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.36.0"}
   "cmdliner" {>= "1.1.0"}
   "process" {>= "0.2.1"}
   "ocaml-protoc-plugin" {>= "6.0.0"}

--- a/nuscr.opam
+++ b/nuscr.opam
@@ -13,7 +13,7 @@ homepage: "https://nuscr.dev/"
 doc: "https://nuscr.dev/nuscr/docs/"
 bug-reports: "https://github.com/nuscr/nuscr/issues"
 depends: [
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "5.1"}
   "menhir" {>= "20190924"}
   "sedlex" {>= "2.5"}
   "ppx_deriving" {>= "5.2"}


### PR DESCRIPTION
## Summary

- Bump `ppxlib` lower bound to `>= 0.36.0` and Jane Street packages (`base`, `stdio`, `ppx_sexp_conv`, `ppx_here`) to `>= v0.17` for OCaml 5.4 compatibility
- Drop OCaml 4 support — Jane Street v0.17 packages all require `ocaml >= 5.1.0`, making it incompatible with the updated bounds
- Update minimum OCaml version in `dune-project` to `5.1`
- Add `5.4` to the CI matrix, remove `4`

## Test plan

- [x] CI passes on OCaml 5.4
- [x] CI continues to pass on OCaml 5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)