### PR TITLE
Fix multiple recursion variables

### DIFF
--- a/lib/mpst/gtype.ml
+++ b/lib/mpst/gtype.ml
@@ -524,25 +524,29 @@ let validate_refinements_exn t =
         List.iter ~f:(aux env) gs ;
         if Pragma.validate_refinement_progress () then ensure_progress env gs
     | MuG (tvar, rec_vars, g) ->
-        let f (tenv, rvenv, role_knowledge)
-            {rv_name; rv_ty; rv_init_expr; rv_roles} =
+        let tenv, rvenv, role_knowledge = env in
+        let rvenv = Map.set ~key:tvar ~data:rec_vars rvenv in
+        let f (tenv, role_knowledge) {rv_name; rv_ty; rv_init_expr; rv_roles}
+            =
           if Expr.is_well_formed_type tenv rv_ty then
             if Expr.check_type tenv rv_init_expr rv_ty then
               let tenv = Expr.env_append tenv rv_name rv_ty in
-              let rvenv = Map.add_exn ~key:tvar ~data:rec_vars rvenv in
               let role_knowledge =
                 List.fold ~init:role_knowledge
                   ~f:(fun acc role -> knowledge_add acc role rv_name)
                   rv_roles
               in
-              (tenv, rvenv, role_knowledge)
+              (tenv, role_knowledge)
             else
               uerr
                 (TypeError
                    (Expr.show rv_init_expr, Expr.show_payload_type rv_ty) )
           else uerr (IllFormedPayloadType (Expr.show_payload_type rv_ty))
         in
-        let env = List.fold ~init:env ~f rec_vars in
+        let tenv, role_knowledge =
+          List.fold ~init:(tenv, role_knowledge) ~f rec_vars
+        in
+        let env = (tenv, rvenv, role_knowledge) in
         aux env g
     | TVarG (tvar, rec_exprs, _) -> (
         let tenv, rvenv, role_knowledge = env in

--- a/test/cram-tests/refinements/recursion-variable.t/Recursion.nuscr
+++ b/test/cram-tests/refinements/recursion-variable.t/Recursion.nuscr
@@ -14,3 +14,10 @@ global protocol Recursion2(role A, role B) {
         continue X [count + 1];
     }
 }
+
+global protocol Recursion3(role A, role B) {
+    rec X [count<A, B>: int = 0, total<A, B>: int = 0] {
+        Add(curr: int{curr = count}, sum: int{sum = total}) from A to B;
+        continue X [count + 1, total + curr];
+    }
+}

--- a/test/cram-tests/refinements/recursion-variable.t/run.t
+++ b/test/cram-tests/refinements/recursion-variable.t/run.t
@@ -47,6 +47,31 @@ The protocol with recursion variable should be well-formed.
     continue X [count + 1];
   }
 
+Multiple recursion variables on the same recursion label should be supported.
+
+  $ nuscr Recursion.nuscr --project A@Recursion3 --show-solver-queries
+  (declare-const count Int)
+  (declare-const freshvar$2 Int)
+  (assert (not (>= count 0)))
+  (assert (= freshvar$2 0))
+  (assert (= freshvar$2 count))
+  (check-sat)
+  
+  (declare-const count Int)
+  (declare-const curr Int)
+  (declare-const freshvar$3 Int)
+  (assert (not (>= count 0)))
+  (assert (= freshvar$3 (+ count 1)))
+  (assert (= freshvar$3 count))
+  (assert (= curr count))
+  (assert (>= count 0))
+  (check-sat)
+  
+  rec X [count<A, B>: int = 0, total<A, B>: int = 0] {
+    Add(curr: (curr:int{curr = count}), sum: (sum:int{sum = total})) to B;
+    continue X [count + 1, total + curr];
+  }
+
 When projected on B, the recursion variable `count` should not appear.
 
   $ nuscr Recursion.nuscr --project B@Recursion1


### PR DESCRIPTION
## Summary
- store recursion variable metadata once per recursion label during refinement validation
- keep validating each declared recursion variable independently
- add a cram regression for multiple recursion variables under one rec label

Fixes #158.

## Verification
- dune build @fmt --auto-promote
- dune runtest test/cram-tests/refinements/recursion-variable.t/
- dune runtest