### PR TITLE
Allow unnamed refined payloads

### DIFF
--- a/lib/syntaxtree/parser.mly
+++ b/lib/syntaxtree/parser.mly
@@ -62,6 +62,13 @@
 %{
 open Syntax
 open Names
+
+let dummy_var_counter = ref 0
+
+let fresh_dummy_var loc =
+  let n = !dummy_var_counter in
+  incr dummy_var_counter ;
+  VariableName.create ("_dummy" ^ string_of_int n) loc
 %}
 %%
 
@@ -75,8 +82,11 @@ let pragma_decl :=
 let pragmas :=
   | PRAGMA_START; ps = separated_list(COMMA, pragma_decl) ; PRAGMA_END ; { ps }
 
+let reset_dummy_vars == { dummy_var_counter := 0 }
+
 (* A file is parsed into a module *)
 let scr_module :=
+  reset_dummy_vars ;
   pgs = pragmas? ; (* Pragma must be at the beginning of a file *)
   nps = nested_protocol_decl* ;
   ps = protocol_decl* ;
@@ -241,6 +251,8 @@ let payload_el ==
   | nm = create_payload(qname) ; < PayloadName >
   | v = varname ; COLON ; t = payloadtypename; LCURLY; e = expr; RCURLY;
     { PayloadRTy (Refined (v, t, e)) }
+  | t = payloadtypename; LCURLY; e = expr; RCURLY;
+    { PayloadRTy (Refined (fresh_dummy_var (Loc.create $loc), t, e)) }
   | ~ = varname ; COLON ; ~ = create_payload(qname) ; < PayloadBnd >
 
 let annotation == ARROBA ; ann = EXTIDENT ; { ann }

--- a/test/cram-tests/codegen/rust-refinement-unnamed-payload.t/UnnamedPayload.nuscr
+++ b/test/cram-tests/codegen/rust-refinement-unnamed-payload.t/UnnamedPayload.nuscr
@@ -5,7 +5,7 @@ global protocol UnnamedPayload(role C, role S) {
     choice at C {
       add(x: int{x > 0}, y: int{y > 0}) from C to S;
       sum(int{x > y}) from S to C;
-      continue loop [total + r];
+      continue loop [total + x];
     } or {
       bye() from C to S;
       bye() from S to C;

--- a/test/cram-tests/codegen/rust-refinement-unnamed-payload.t/run.t
+++ b/test/cram-tests/codegen/rust-refinement-unnamed-payload.t/run.t
@@ -1,10 +1,175 @@
-nuscr rejects UnnamedPayload: refinement on payload with no variable binding
+nuscr generates UnnamedPayload: refinement on payload with a dummy binding
   $ nuscr --gencode-rust-test=C@UnnamedPayload UnnamedPayload.nuscr
-  nuscr: User error: Parser error: An error occurred at 7:14 to 7:15 in:
-         UnnamedPayload.nuscr
-  [124]
+  pub enum Direction {
+      Recv,
+      Send,
+  }
+  
+  #[allow(dead_code)]
+  pub enum Action {
+      Add { dir: Direction, x: i64, y: i64 },
+      Bye { dir: Direction },
+      Sum { dir: Direction, _dummy0: i64 },
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Violation {
+      ConstraintFailed { expr: &'static str },
+      NoMatchingTransition,
+      AlreadyFailed,
+  }
+  
+  impl std::fmt::Display for Violation {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+          match self {
+              Violation::ConstraintFailed { expr } => write!(f, "constraint failed: {expr}"),
+              Violation::NoMatchingTransition => write!(f, "no matching transition"),
+              Violation::AlreadyFailed => write!(f, "already failed"),
+          }
+      }
+  }
+  
+  impl std::error::Error for Violation {}
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[allow(dead_code)]
+  enum UnnamedPayloadState {
+      S0 { total: i64 },
+      S3 { total: i64, x: i64, y: i64 },
+      S5 { total: i64 },
+      S6 { total: i64 },
+      Error,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct UnnamedPayloadMonitor { state: UnnamedPayloadState }
+  
+  #[allow(unused_variables)]
+  impl UnnamedPayloadMonitor {
+      pub fn new() -> Self {
+          Self { state: UnnamedPayloadState::S0 { total: 0 } }
+      }
+  
+      pub fn accepts(&self, action: &Action) -> bool {
+          match action {
+              Action::Bye { dir: Direction::Recv, .. } => true,
+              Action::Sum { dir: Direction::Recv, _dummy0, .. } => true,
+              Action::Add { dir: Direction::Send, x, y, .. } => {
+                  let x = *x;
+                  let y = *y;
+                  ((x) > (0)) && ((y) > (0))
+              }
+              Action::Bye { dir: Direction::Send, .. } => true,
+              _ => false,
+          }
+      }
+  
+      pub fn step(&mut self, action: &Action) -> Result<(), Violation> {
+          match (&self.state, action) {
+              (UnnamedPayloadState::Error, _) => Err(Violation::AlreadyFailed),
+              (UnnamedPayloadState::S0 { total }, Action::Add { dir: Direction::Send, x, y, .. }) => {
+                  let total = *total;
+                  let x = *x;
+                  let y = *y;
+                  if !(((x) > (0)) && ((y) > (0))) { self.state = UnnamedPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "((x) > (0)) && ((y) > (0))" }); }
+                  self.state = UnnamedPayloadState::S3 { total, x, y };
+                  Ok(())
+              }
+              (UnnamedPayloadState::S0 { total }, Action::Bye { dir: Direction::Send, .. }) => {
+                  let total = *total;
+                  self.state = UnnamedPayloadState::S5 { total };
+                  Ok(())
+              }
+              (UnnamedPayloadState::S3 { total, x, y }, Action::Sum { dir: Direction::Recv, _dummy0, .. }) => {
+                  let total = *total;
+                  let x = *x;
+                  let y = *y;
+                  let _dummy0 = *_dummy0;
+                  if !((x) > (y)) { self.state = UnnamedPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(x) > (y)" }); }
+                  let new_total = (total) + (x);
+                  if !((new_total) < (100)) { self.state = UnnamedPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(total) < (100)" }); }
+                  self.state = UnnamedPayloadState::S0 { total: new_total };
+                  Ok(())
+              }
+              (UnnamedPayloadState::S5 { total }, Action::Bye { dir: Direction::Recv, .. }) => {
+                  let total = *total;
+                  self.state = UnnamedPayloadState::S6 { total };
+                  Ok(())
+              }
+              _ => { self.state = UnnamedPayloadState::Error; Err(Violation::NoMatchingTransition) }
+          }
+      }
+  }
+  
 
   $ nuscr --gencode-rust=C@UnnamedPayload UnnamedPayload.nuscr
-  nuscr: User error: Parser error: An error occurred at 7:14 to 7:15 in:
-         UnnamedPayload.nuscr
-  [124]
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[allow(dead_code)]
+  enum UnnamedPayloadState {
+      S0 { total: i64 },
+      S3 { total: i64, x: i64, y: i64 },
+      S5 { total: i64 },
+      S6 { total: i64 },
+      Error,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct UnnamedPayloadMonitor { state: UnnamedPayloadState }
+  
+  #[allow(unused_variables)]
+  impl UnnamedPayloadMonitor {
+      pub fn new() -> Self {
+          Self { state: UnnamedPayloadState::S0 { total: 0 } }
+      }
+  
+      pub fn accepts(&self, action: &Action) -> bool {
+          match action {
+              Action::Bye { dir: Direction::Recv, .. } => true,
+              Action::Sum { dir: Direction::Recv, _dummy0, .. } => true,
+              Action::Add { dir: Direction::Send, x, y, .. } => {
+                  let x = *x;
+                  let y = *y;
+                  ((x) > (0)) && ((y) > (0))
+              }
+              Action::Bye { dir: Direction::Send, .. } => true,
+              _ => false,
+          }
+      }
+  
+      pub fn step(&mut self, action: &Action) -> Result<(), Violation> {
+          match (&self.state, action) {
+              (UnnamedPayloadState::Error, _) => Err(Violation::AlreadyFailed),
+              (UnnamedPayloadState::S0 { total }, Action::Add { dir: Direction::Send, x, y, .. }) => {
+                  let total = *total;
+                  let x = *x;
+                  let y = *y;
+                  if !(((x) > (0)) && ((y) > (0))) { self.state = UnnamedPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "((x) > (0)) && ((y) > (0))" }); }
+                  self.state = UnnamedPayloadState::S3 { total, x, y };
+                  Ok(())
+              }
+              (UnnamedPayloadState::S0 { total }, Action::Bye { dir: Direction::Send, .. }) => {
+                  let total = *total;
+                  self.state = UnnamedPayloadState::S5 { total };
+                  Ok(())
+              }
+              (UnnamedPayloadState::S3 { total, x, y }, Action::Sum { dir: Direction::Recv, _dummy0, .. }) => {
+                  let total = *total;
+                  let x = *x;
+                  let y = *y;
+                  let _dummy0 = *_dummy0;
+                  if !((x) > (y)) { self.state = UnnamedPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(x) > (y)" }); }
+                  let new_total = (total) + (x);
+                  if !((new_total) < (100)) { self.state = UnnamedPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(total) < (100)" }); }
+                  self.state = UnnamedPayloadState::S0 { total: new_total };
+                  Ok(())
+              }
+              (UnnamedPayloadState::S5 { total }, Action::Bye { dir: Direction::Recv, .. }) => {
+                  let total = *total;
+                  self.state = UnnamedPayloadState::S6 { total };
+                  Ok(())
+              }
+              _ => { self.state = UnnamedPayloadState::Error; Err(Violation::NoMatchingTransition) }
+          }
+      }
+  }
+  


### PR DESCRIPTION
## Summary
- allow the parser to accept unnamed refined payloads such as `int{x > y}`
- assign deterministic dummy binders like `_dummy0` for unnamed refinements
- update the Rust codegen cram test expectations for unnamed payload refinements

## Tests
- `dune build`
- `dune runtest test/cram-tests/codegen/rust-refinement-unnamed-payload.t`
- `dune runtest test/cram-tests/codegen/rust-refinement-multi-payload.t`
- generated monitor compiled with `rustc --edition 2021 --crate-type lib`
- `dune runtest`